### PR TITLE
feat: add login user's 'like' flag for item

### DIFF
--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/favourite/controller/FavouriteController.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/favourite/controller/FavouriteController.java
@@ -11,6 +11,7 @@ import cucumbermarket.cucumbermarketspring.domain.member.Member;
 import cucumbermarket.cucumbermarketspring.domain.member.service.MemberService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -30,6 +31,7 @@ public class FavouriteController {
      * */
     @PostMapping("/favourite")
     @CrossOrigin
+    @ResponseStatus(HttpStatus.CREATED)
     public CreateFavItemResponseDto create(@RequestBody CreateFavItemRequestDto createRequest){
         Item item = itemService.searchItemById(createRequest.getItemid());
         Member member = memberService.searchMemberById(createRequest.getMemberid());

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/favourite/service/FavouriteService.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/favourite/service/FavouriteService.java
@@ -97,4 +97,24 @@ public class FavouriteService {
 
         return count;
     }
+
+    /**
+     *  내가 찜하기 누른 상품인지 판별
+     */
+    @Transactional(readOnly = true)
+    public Boolean isItMine(Long loginId, Long itemId) {
+        JPAQueryFactory queryFactory = new JPAQueryFactory(em);
+
+        QFavouriteItem favouriteItem = QFavouriteItem.favouriteItem;
+
+        Long count = queryFactory
+                .selectFrom(favouriteItem)
+                .where(favouriteItem.item.id.eq(itemId).and(favouriteItem.member.id.eq(loginId)))
+                .fetchCount();
+
+        if(count == 1)
+            return true;
+        else
+            return false;
+    }
 }

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/controller/ItemController.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/controller/ItemController.java
@@ -12,7 +12,6 @@ import cucumbermarket.cucumbermarketspring.domain.item.dto.*;
 import cucumbermarket.cucumbermarketspring.domain.item.service.ItemService;
 import cucumbermarket.cucumbermarketspring.domain.member.Member;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
-import cucumbermarket.cucumbermarketspring.domain.member.address.AddressService;
 import cucumbermarket.cucumbermarketspring.domain.member.service.MemberService;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -156,9 +155,9 @@ public class ItemController {
     /**
      * 물품 개별 조회
      */
-    @GetMapping("/item/{id}")
+    @GetMapping("/item/{id}/{member}")
     @CrossOrigin
-    public ItemResponseDto findById(@PathVariable("id") Long id){
+    public ItemResponseDto findById(@PathVariable Long id, @PathVariable Long member){
         List<PhotoResponseDto> photoResponseDtoList = fileService.findAllByItem(id);
         List<Long> photoId = new ArrayList<>();
         for(PhotoResponseDto photoResponseDto : photoResponseDtoList)
@@ -167,7 +166,9 @@ public class ItemController {
         Item item = itemService.searchItemById(id);
         itemService.updateViews(id, item.getViews());
         Long favourite = favouriteService.countFavourite(id);
-        return itemService.findOne(id, photoId, favourite);
+        Boolean mine = favouriteService.isItMine(member, id);
+
+        return itemService.findOne(id, photoId, favourite, mine);
     }
 
     /**
@@ -181,7 +182,8 @@ public class ItemController {
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(memberId, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 
@@ -199,7 +201,8 @@ public class ItemController {
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(memberId, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 
@@ -209,15 +212,19 @@ public class ItemController {
     /**
      * 물품 전체 조회(구 기준)
      */
-    @GetMapping("/item/area")
+    @GetMapping("/item/area/{id}")
     @CrossOrigin
-    public List<ItemListResponseDto> findByArea(@RequestParam("city") String city, @RequestParam("street") String street) {
+    public List<ItemListResponseDto> findByArea(
+            @PathVariable Long id,
+            @RequestParam("city") String city,
+            @RequestParam("street") String street) {
         List<Item> itemList = itemService.findByArea(city, street);
         List<ItemListResponseDto> responseDtoList = new ArrayList<>();
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(id, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 
@@ -227,16 +234,17 @@ public class ItemController {
     /**
      * 물품 전체 조회(카테고리 기준)
      */
-    @GetMapping("/item/search/1")
+    @GetMapping("/item/search/1/{id}")
     @CrossOrigin
-    public List<ItemListResponseDto> findByCategory(@RequestParam("category") String category) {
+    public List<ItemListResponseDto> findByCategory(@PathVariable Long id, @RequestParam("category") String category) {
         Categories categories = Categories.find(category);
         List<Item> itemList = itemService.findByCategory(categories);
         List<ItemListResponseDto> responseDtoList = new ArrayList<>();
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(id, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 
@@ -246,15 +254,16 @@ public class ItemController {
     /**
      * 물품 전체 조회(키워드 기준)
      */
-    @GetMapping("/item/search/2")
+    @GetMapping("/item/search/2/{id}")
     @CrossOrigin
-    public List<ItemListResponseDto> findByKeyword(@RequestParam("keyword") String keyword) {
+    public List<ItemListResponseDto> findByKeyword(@PathVariable Long id, @RequestParam("keyword") String keyword) {
         List<Item> itemList = itemService.findByKeyword(keyword);
         List<ItemListResponseDto> responseDtoList = new ArrayList<>();
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(id, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 
@@ -264,15 +273,16 @@ public class ItemController {
     /**
      * 물품 전체 조회
      */
-    @GetMapping("/item/list")
+    @GetMapping("/item/list/{id}")
     @CrossOrigin
-    public List<ItemListResponseDto> findAll() {
+    public List<ItemListResponseDto> findAll(@PathVariable Long id) {
         List<Item> itemList = itemService.findAll();
         List<ItemListResponseDto> responseDtoList = new ArrayList<>();
 
         for(Item item : itemList){
             Long favourite = favouriteService.countFavourite(item.getId());
-            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite);
+            Boolean mine = favouriteService.isItMine(id, item.getId());
+            ItemListResponseDto responseDto = new ItemListResponseDto(item, favourite, mine);
             responseDtoList.add(responseDto);
         }
 

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemListResponseDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemListResponseDto.java
@@ -17,11 +17,12 @@ public class ItemListResponseDto {
     private Boolean sold;
     private LocalDateTime created;
     private int views;
-    private Long favourite;
+    private Long favCnt;
+    private Boolean like;
     private Long thumbnailid;
 
 
-    public ItemListResponseDto(Item entity, Long favourite) {
+    public ItemListResponseDto(Item entity, Long favCnt, Boolean like) {
         this.id = entity.getId();
         this.member = entity.getMember().getUsername();
         this.city = entity.getAddress().getCity();
@@ -32,7 +33,8 @@ public class ItemListResponseDto {
         this.sold = entity.getSold();
         this.created = entity.getCreated();
         this.views = entity.getViews();
-        this.favourite = favourite;
+        this.favCnt = favCnt;
+        this.like = like;
 
         if(!entity.getPhoto().isEmpty())
             this.thumbnailid = entity.getPhoto().get(0).getId();

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemResponseDto.java
@@ -19,11 +19,12 @@ public class ItemResponseDto {
     private Boolean sold;
     private LocalDateTime created;
     private int views;
-    private Long favourite;
+    private Long favCnt;
+    private Boolean like;
     private List<Long> fileid;
     private Long buyerId;
 
-    public ItemResponseDto(Item entity, List<Long> fileId, Long favourite){
+    public ItemResponseDto(Item entity, List<Long> fileId, Long favCnt, Boolean like){
         this.id = entity.getId();
         this.member = entity.getMember().getName();
         this.title = entity.getTitle();
@@ -36,7 +37,8 @@ public class ItemResponseDto {
         this.created = entity.getCreated();
         this.views = entity.getViews();
         this.buyerId = entity.getBuyerId();
-        this.favourite = favourite;
+        this.favCnt = favCnt;
+        this.like = like;
         this.fileid = fileId;
     }
 }

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/service/ItemService.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/service/ItemService.java
@@ -107,11 +107,11 @@ public class ItemService {
      * 상품 개별 조회(정보 + 파일)
      * */
     @Transactional(readOnly = true)
-    public ItemResponseDto findOne(Long id, List<Long> fileId, Long count){
+    public ItemResponseDto findOne(Long id, List<Long> fileId, Long count, Boolean mine){
         Item entity = itemRepository.findById(id).orElseThrow(()
                 -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
 
-        return new ItemResponseDto(entity, fileId, count);
+        return new ItemResponseDto(entity, fileId, count, mine);
     }
 
     /**

--- a/src/main/java/cucumbermarket/cucumbermarketspring/security/SecurityConfig.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/security/SecurityConfig.java
@@ -1,9 +1,7 @@
 package cucumbermarket.cucumbermarketspring.security;
 
-import com.google.common.collect.ImmutableList;
 import cucumbermarket.cucumbermarketspring.domain.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -20,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -35,7 +34,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             "/category", "/item/**","/item", "/item/list", "/item/area",
             "/thumbnail/**", "/image/**",
             "/test", "/webjars/**", "/ws/**", "/user/**", "/chat/**",
-            "/review/list/**","/message/**", "/console/**"
+            "/review/list/**", "/message/**", "/console/**",
+            "/favourite", "/favourite/**"
     };
 
     @Bean


### PR DESCRIPTION
로그인 한 유저가 '좋아요' 버튼을 눌렀다는 flag 전송
- controller의 `GET` 관련 메소드들 중 member_id 전달받지 않는 메소드들의 인자 수정
- (list)responsDTO 내 `like` 필드 추가
- 기존 좋아요 갯수 필드 `favourite`을 `favCnt`로 변경
- `SecurityConfig`에 PUBLIC_URI에 추가(임시)