### PR TITLE
feat: add feature for item status

### DIFF
--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/Item.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/Item.java
@@ -6,6 +6,7 @@ import cucumbermarket.cucumbermarketspring.domain.BaseTimeEntity;
 import cucumbermarket.cucumbermarketspring.domain.favourite.FavouriteItem;
 import cucumbermarket.cucumbermarketspring.domain.file.Photo;
 import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.Member;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
 import cucumbermarket.cucumbermarketspring.domain.review.Review;
@@ -53,7 +54,8 @@ public class Item extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String spec;
 
-    private Boolean sold;
+    @Enumerated(EnumType.STRING)
+    private Status sold;
 
     @Column(columnDefinition = "int default 0")
     private int views;
@@ -72,7 +74,7 @@ public class Item extends BaseTimeEntity {
      * 빌더
      * */
     @Builder
-    public Item(Member member, Long buyerId, String title, Categories categories, int price, String spec, Address address, Boolean sold, int views){
+    public Item(Member member, Long buyerId, String title, Categories categories, int price, String spec, Address address, Status sold, int views){
         this.member = member;
         this.buyerId = buyerId;
         this.title = title;
@@ -84,7 +86,7 @@ public class Item extends BaseTimeEntity {
         this.views = views;
     }
 
-    public void update(String title, Categories categories, int price, String spec, Address address, Boolean sold){
+    public void update(String title, Categories categories, int price, String spec, Address address, Status sold){
         this.title = title;
         this.address = address;
         this.categories = categories;
@@ -97,7 +99,11 @@ public class Item extends BaseTimeEntity {
         this.views = views + 1;
     }
 
-    public void soldOut(Boolean sold, Long memberId){
+    public void changeStatus(Status sold) {
+        this.sold = sold;
+    }
+
+    public void soldOut(Status sold, Long memberId){
         this.sold = sold;
         this.buyerId = memberId;
     }

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/controller/ItemController.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/controller/ItemController.java
@@ -10,6 +10,7 @@ import cucumbermarket.cucumbermarketspring.domain.item.ItemFileVO;
 import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
 import cucumbermarket.cucumbermarketspring.domain.item.dto.*;
 import cucumbermarket.cucumbermarketspring.domain.item.service.ItemService;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.Member;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
 import cucumbermarket.cucumbermarketspring.domain.member.service.MemberService;
@@ -44,9 +45,8 @@ public class ItemController {
         Member member = memberService.searchMemberById(Long.parseLong(itemFileVO.getId()));
         Address address = new Address(itemFileVO.getCity(), itemFileVO.getStreet1(), "", "");
         Categories category = Categories.find(itemFileVO.getCategory());
-//        Categories category = Categories.valueOf(itemFileVO.getCategory());
         int price = Integer.parseInt(itemFileVO.getPrice());
-        Boolean sold = Boolean.parseBoolean(itemFileVO.getSold());
+        Status sold = Status.find(itemFileVO.getSold());
 
         ItemCreateRequestDto itemRequestDto = ItemCreateRequestDto.builder()
                         .member(member)
@@ -70,10 +70,9 @@ public class ItemController {
     @CrossOrigin
     public CreateUpdateItemResponseDto update(@PathVariable Long id, ItemFileVO itemFileVO) throws Exception {
         Address address = new Address(itemFileVO.getCity(), itemFileVO.getStreet1(), "", "");
-    //    Categories category = Categories.find(itemFileVO.getCategory());
-        Categories category = Categories.valueOf(itemFileVO.getCategory());
+        Categories category = Categories.find(itemFileVO.getCategory());
         int price = Integer.parseInt(itemFileVO.getPrice());
-        Boolean sold = Boolean.parseBoolean(itemFileVO.getSold());
+        Status sold = Status.find(itemFileVO.getSold());
 
         ItemUpdateRequestDto itemRequestDto = ItemUpdateRequestDto.builder()
                 .address(address)
@@ -135,6 +134,21 @@ public class ItemController {
         try {
             itemService.soldOut(itemSoldDto.getItemId(), itemSoldDto.getBuyerId());
             chatRoomService.updateValid(itemSoldDto.getItemId(), itemSoldDto.getBuyerId(), itemSoldDto.getSellerId());
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이미 판매된 상품입니다");
+        }
+        return ResponseEntity.ok().body("OK");
+    }
+
+    /**
+     * 상태 변경
+     */
+    @PostMapping("/item/change")
+    @CrossOrigin
+    public ResponseEntity<?> change(@RequestBody ItemStatusDto itemStatusDto) {
+        try {
+            Status sold = Status.find(itemStatusDto.getStatus());
+            itemService.changeState(itemStatusDto.getItemId(), sold);
         } catch (IllegalArgumentException e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("이미 판매된 상품입니다");
         }

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemCreateRequestDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemCreateRequestDto.java
@@ -2,6 +2,7 @@ package cucumbermarket.cucumbermarketspring.domain.item.dto;
 
 import cucumbermarket.cucumbermarketspring.domain.item.Item;
 import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.Member;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
 import lombok.Builder;
@@ -17,10 +18,10 @@ public class ItemCreateRequestDto {
     private int price;
     private String spec;
     private Address address;
-    private Boolean sold;
+    private Status sold;
 
     @Builder
-    public ItemCreateRequestDto(Member member, String title, Categories categories, int price, String spec, Address address, Boolean sold){
+    public ItemCreateRequestDto(Member member, String title, Categories categories, int price, String spec, Address address, Status sold){
         this.member = member;
         this.title = title;
         this.categories = categories;

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemListResponseDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemListResponseDto.java
@@ -14,7 +14,7 @@ public class ItemListResponseDto {
     private String title;
     private String categories;
     private int price;
-    private Boolean sold;
+    private String sold;
     private LocalDateTime created;
     private int views;
     private Long favCnt;
@@ -30,7 +30,7 @@ public class ItemListResponseDto {
         this.title = entity.getTitle();
         this.categories = entity.getCategories().getValue();
         this.price = entity.getPrice();
-        this.sold = entity.getSold();
+        this.sold = entity.getSold().getValue();
         this.created = entity.getCreated();
         this.views = entity.getViews();
         this.favCnt = favCnt;

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemResponseDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemResponseDto.java
@@ -16,7 +16,7 @@ public class ItemResponseDto {
     private String spec;
     private String city;
     private String street;
-    private Boolean sold;
+    private String sold;
     private LocalDateTime created;
     private int views;
     private Long favCnt;
@@ -33,7 +33,7 @@ public class ItemResponseDto {
         this.spec = entity.getSpec();
         this.city = entity.getAddress().getCity();
         this.street = entity.getAddress().getStreet1();
-        this.sold = entity.getSold();
+        this.sold = entity.getSold().getValue();
         this.created = entity.getCreated();
         this.views = entity.getViews();
         this.buyerId = entity.getBuyerId();

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemStatusDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemStatusDto.java
@@ -1,0 +1,9 @@
+package cucumbermarket.cucumbermarketspring.domain.item.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ItemStatusDto {
+    private Long itemId;
+    private String status;
+}

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemUpdateRequestDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/dto/ItemUpdateRequestDto.java
@@ -1,6 +1,7 @@
 package cucumbermarket.cucumbermarketspring.domain.item.dto;
 
 import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,10 +15,10 @@ public class ItemUpdateRequestDto {
     private int price;
     private String spec;
     private Address address;
-    private Boolean sold;
+    private Status sold;
 
     @Builder
-    public ItemUpdateRequestDto(String title, Categories categories, int price, String spec, Address address, Boolean sold){
+    public ItemUpdateRequestDto(String title, Categories categories, int price, String spec, Address address, Status sold){
         this.title = title;
         this.categories = categories;
         this.price = price;

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/service/ItemService.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/service/ItemService.java
@@ -11,6 +11,7 @@ import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
 import cucumbermarket.cucumbermarketspring.domain.item.dto.ItemCreateRequestDto;
 import cucumbermarket.cucumbermarketspring.domain.item.dto.ItemResponseDto;
 import cucumbermarket.cucumbermarketspring.domain.item.dto.ItemUpdateRequestDto;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.address.QAddress;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -86,10 +87,23 @@ public class ItemService {
     public void soldOut(Long itemId, Long buyerId) {
         Item item = itemRepository.findById(itemId).orElseThrow(()
                 -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
-        if (item.getSold() == true) {
+        if (item.getSold().getValue().equals(Status.SOLD)) {
             throw new IllegalArgumentException("이미 판매된 상품입니다");
         }
-        item.soldOut(true, buyerId);
+        item.soldOut(Status.SOLD, buyerId);
+    }
+
+    /**
+    * 상품 판매 상태 변경
+    * */
+    @Transactional
+    public void changeState(Long itemId, Status status) {
+        Item item = itemRepository.findById(itemId).orElseThrow(()
+                -> new IllegalArgumentException("해당 상품이 존재하지 않습니다."));
+        if (item.getSold().getValue().equals(Status.SOLD)) {
+            throw new IllegalArgumentException("이미 판매된 상품입니다");
+        }
+        item.changeStatus(status);
     }
 
     /**

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/Status.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/Status.java
@@ -1,0 +1,33 @@
+package cucumbermarket.cucumbermarketspring.domain.item.status;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@JsonFormat(shape = Shape.OBJECT)
+@Getter
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+public enum Status {
+    SOLD("판매완료"),
+    RESERVED("예약중"),
+    SALE("판매중");
+
+    private final String value;
+
+    private static final Map<String, Status> values =
+            Collections.unmodifiableMap(Stream.of(values())
+                    .collect(Collectors.toMap(Status::getValue, Function.identity())));
+
+    public static Status find(String value){
+        return Optional.ofNullable(values.get(value)).orElse(SALE);
+    }
+}

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusController.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusController.java
@@ -1,0 +1,20 @@
+package cucumbermarket.cucumbermarketspring.domain.item.status;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class StatusController {
+
+    private final StatusService statusService;
+
+    @GetMapping("/status")
+    private List<StatusResponseDto> findAll(){
+        return statusService.findAll();
+    }
+
+}

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusResponseDto.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusResponseDto.java
@@ -1,0 +1,16 @@
+package cucumbermarket.cucumbermarketspring.domain.item.status;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class StatusResponseDto {
+    private String key;
+    private String value;
+
+    public StatusResponseDto(Status status){
+        this.key = status.name();
+        this.value = status.getValue();
+    }
+}

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusService.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/item/status/StatusService.java
@@ -1,0 +1,19 @@
+package cucumbermarket.cucumbermarketspring.domain.item.status;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class StatusService {
+    public List<StatusResponseDto> findAll(){
+        return Arrays
+                .stream(Status.class.getEnumConstants())
+                .map(StatusResponseDto::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/cucumbermarket/cucumbermarketspring/domain/member/InitMember.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/domain/member/InitMember.java
@@ -2,12 +2,11 @@ package cucumbermarket.cucumbermarketspring.domain.member;
 
 import cucumbermarket.cucumbermarketspring.domain.chat.InitChat;
 import cucumbermarket.cucumbermarketspring.domain.item.Item;
-import cucumbermarket.cucumbermarketspring.domain.item.ItemRepository;
 import cucumbermarket.cucumbermarketspring.domain.item.category.Categories;
+import cucumbermarket.cucumbermarketspring.domain.item.status.Status;
 import cucumbermarket.cucumbermarketspring.domain.member.address.Address;
 import cucumbermarket.cucumbermarketspring.domain.member.address.AddressVO;
 import lombok.RequiredArgsConstructor;
-import org.springframework.core.annotation.Order;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -91,7 +90,7 @@ public class InitMember {
             );
             em.persist(member);
             if (i == 1){
-                Item item = new Item(member, null, "장미 팝니다", Categories.LIVING, 3000, "관리 힘듦요", address, Boolean.FALSE, 0);
+                Item item = new Item(member, null, "장미 팝니다", Categories.LIVING, 3000, "관리 힘듦요", address, Status.SALE, 0);
                 em.persist(item);
             }
             if (i == 2) {
@@ -99,7 +98,7 @@ public class InitMember {
                         member,
                         null,
                         "아이폰 8 팝니다",
-                        Categories.DIGIT, 200000, "아이폰 8 싸게 팝니다.", address, Boolean.FALSE, 0);
+                        Categories.DIGIT, 200000, "아이폰 8 싸게 팝니다.", address, Status.SALE, 0);
                 em.persist(item);
             }
         }

--- a/src/main/java/cucumbermarket/cucumbermarketspring/security/SecurityConfig.java
+++ b/src/main/java/cucumbermarket/cucumbermarketspring/security/SecurityConfig.java
@@ -31,7 +31,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private static final String[] PUBLIC_URI = {
             "/", "/login", "/address/city/**", "/member",
-            "/category", "/item/**","/item", "/item/list", "/item/area",
+            "/category", "/item/**","/item", "/item/list", "/item/area", "/status",
             "/thumbnail/**", "/image/**",
             "/test", "/webjars/**", "/ws/**", "/user/**", "/chat/**",
             "/review/list/**", "/message/**", "/console/**",


### PR DESCRIPTION
상품 상태 관련 기능 수정 및 추가
- 상품 상태를 `boolean` 타입에서 **enum 클래스**인 **`Status`** 로 변경하여 관리
- 상태는 총 3가지 - 판매중(기본), 예약중, 판매완료
- 상품 판매 상태를 변경하는 메소드  `change()` 추가